### PR TITLE
feat: add Password value object and model.value package

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -48,6 +48,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- password設定用  -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+
         <!-- テスト用 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/calendar/milestone/model/value/Password.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Password.java
@@ -1,0 +1,22 @@
+package com.calendar.milestone.model.value;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class Password {
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    final String encodedPassword;
+    private final int PASSWORD_LENGTH_MIN = 8;
+    private final int PASSWORD_LENGTH_MAX = 20;
+
+    private Password(String defaultPassword) throws IllegalArgumentException{
+        if(defaultPassword.length() < PASSWORD_LENGTH_MIN){ throw new IllegalArgumentException("Argument too short");}
+        if(defaultPassword.length() > PASSWORD_LENGTH_MAX){throw new IllegalArgumentException("Argument too long");}
+        encodedPassword = passwordEncoder.encode(defaultPassword);
+        
+    }
+
+    public static Password encode(String defaultPassword){
+        return new Password(defaultPassword);
+    }
+
+}


### PR DESCRIPTION
# Overview
- Introduced `Password` class to encapsulate password encoding logic using BCrypt
- Added `model.value` package to organize domain-level value objects

# Additional Changes
- Added `spring-boot-starter-security` dependency in `pom.xml` to enable password encryption

# Note
- The `Password` class includes basic length validation (min: 8, max: 20)
- Logging functionality is not yet implemented and will be added in a future update
- Unit tests for `Password` are not yet implemented; testing will be done after the full backend service flow is in place