### PR TITLE
fix: add missing getter and setter for password in UserRequest

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserRequest.java
@@ -56,6 +56,10 @@ public class UserRequest {
         return email;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
     public void setId(int id) {
         this.id = id;
     }
@@ -74,5 +78,9 @@ public class UserRequest {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 }


### PR DESCRIPTION
## Overview
Added the missing getter and setter methods for the `password` field in `UserRequest`.

## Details
- Previously forgot to add the methods after introducing the `password` field.
- This is necessary for binding request values and future validation logic.

## Note
Oops. Just patching what I forgot earlier :)
