### PR TITLE
add: SecurityConfig to temporarily disable Spring Security for development

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/config/SecurityConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/config/SecurityConfig.java
@@ -1,0 +1,17 @@
+package com.calendar.milestone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/calendar/milestone/controller/UserController.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/UserController.java
@@ -36,7 +36,6 @@ public class UserController {
     @PutMapping("/{id}")
     public int updateUser(@PathVariable int id, @RequestBody @Valid UserPutRequest user) {
         user.setId(id);
-        System.out.println("User Controller");
         return userService.update(user);
     }
 

--- a/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
@@ -56,9 +56,10 @@ public class UserRepository {
     }
 
     public int update(User user) {
-        final String sql = "update users set name=?,photo=?,birthday=?,email=? where id=?";
+        final String sql =
+                "update users set name=?,photo=?,birthday=?,email=?,password=? where id=?";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getId());
+                user.getEmail(), user.getPassword().getEncordedPassword(), user.getId());
     }
 
     public int delete(int id) {

--- a/backend/src/main/java/com/calendar/milestone/model/service/UserService.java
+++ b/backend/src/main/java/com/calendar/milestone/model/service/UserService.java
@@ -5,6 +5,7 @@ import com.calendar.milestone.controller.dto.request.UserRequest;
 import com.calendar.milestone.controller.dto.response.UserResponse;
 import com.calendar.milestone.model.entity.User;
 import com.calendar.milestone.model.repository.UserRepository;
+import com.calendar.milestone.model.value.Password;
 import org.springframework.stereotype.Service;
 
 
@@ -17,19 +18,22 @@ public class UserService {
     }
 
 
-    public User convertToUserUpdate(UserPutRequest userRequest) {
-        User user = userRepository.select(userRequest.getId());
-        if (userRequest.getName() != null) {
-            user.setName(userRequest.getName());
+    public User convertToUserUpdate(UserPutRequest userPutRequest) {
+        User user = userRepository.select(userPutRequest.getId());
+        if (userPutRequest.getName() != null) {
+            user.setName(userPutRequest.getName());
         }
-        if (userRequest.getEmail() != null) {
-            user.setEmail(userRequest.getEmail());
+        if (userPutRequest.getEmail() != null) {
+            user.setEmail(userPutRequest.getEmail());
         }
-        if (userRequest.getPhoto() != null) {
-            user.setPhoto(userRequest.getPhoto());
+        if (userPutRequest.getPhoto() != null) {
+            user.setPhoto(userPutRequest.getPhoto());
         }
-        if (userRequest.getBirthday() != null) {
-            user.setBirthday(userRequest.getBirthday());
+        if (userPutRequest.getBirthday() != null) {
+            user.setBirthday(userPutRequest.getBirthday());
+        }
+        if (userPutRequest.getPassword() != null) {
+            user.setPassword(Password.encode(userPutRequest.getPassword()));
         }
         return user;
     }
@@ -70,7 +74,6 @@ public class UserService {
     }
 
     public int update(UserPutRequest userPutRequest) {
-        System.out.println("User service");
         return userRepository.update(convertToUserUpdate(userPutRequest));
     }
 

--- a/backend/src/main/java/com/calendar/milestone/model/value/Password.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Password.java
@@ -23,4 +23,8 @@ public class Password {
         return new Password(defaultPassword);
     }
 
+    public String getEncordedPassword() {
+        return encodedPassword;
+    }
+
 }


### PR DESCRIPTION
# Overview
- Added `SecurityConfig` to disable authentication for development purposes

# Note
- This bypasses Spring Security to allow `POST` and `PUT` requests without credentials
- Necessary due to Spring Security being introduced with `Password` value object
- Will be revised or removed before production
