### PR TITLE
fix: use encoded password string in UserRepository.insert

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/UserController.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.calendar.milestone.controller;
 
 import com.calendar.milestone.controller.dto.request.UserPutRequest;
-import com.calendar.milestone.controller.dto.request.UserRequest;
+import com.calendar.milestone.controller.dto.request.UserPostRequest;
 import com.calendar.milestone.controller.dto.response.UserResponse;
 import com.calendar.milestone.model.service.UserService;
 import jakarta.validation.Valid;
@@ -24,7 +24,7 @@ public class UserController {
     }
 
     @PostMapping
-    public int insertUser(@RequestBody @Valid UserRequest user) {
+    public int insertUser(@RequestBody @Valid UserPostRequest user) {
         return userService.insert(user);
     }
 

--- a/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
@@ -53,7 +53,7 @@ public class UserRepository {
         final String sql =
                 "insert into users(name,photo,birthday,email,password) values(?,?,?,?,?)";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getPassword());
+                user.getEmail(), user.getPassword().getEncordedPassword());
     }
 
     public int update(User user) {


### PR DESCRIPTION
## Class:
UserRepository

## Method:
insert

## Issue:
An error occurred when executing a POST request via curl. The password was passed as a class instance directly into the SQL statement, causing a type mismatch.

## Cause:
The method `user.getPassword()` returns an instance of the `Password` class, not a `String`. As a result, when binding parameters in the SQL statement, a type incompatibility occurred during execution.

## Fix:
Changed the argument from `user.getPassword()` to `user.getPassword().getEncordedPassword()` so that the encoded password string is passed to the SQL query.

## Note:
Confirmed that the POST request via curl now executes successfully after the fix.
