### PR TITLE
feat: add password validation to UserPostRequest DTO using @Pattern

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserPostRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserPostRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 
@@ -32,6 +33,9 @@ public class UserPostRequest {
     @JsonProperty("password")
     @NotNull
     @Size(min = 8, max = 200)
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
+            message = "Password must contain uppercase, lowercase, digit, and special character.")
     private String password;
 
     public String getName() {


### PR DESCRIPTION
## Class:
UserPostRequest.java

## Method:
N/A (Field annotation only)

## Issue:
The user registration DTO did not validate password format.

## Cause:
The password field lacked any validation for structure or strength, which could allow weak or invalid passwords to pass through.

## Fix:
Added validation annotations (`@Pattern`) to the `password` field in the `UserPostRequest` DTO.

- Ensures password is 8–20 characters long
- Requires uppercase, lowercase, digit, and special character

## Note:
This is the first step in enforcing password security rules at the backend.  
Frontend validation is already applied; this change aligns the backend with those rules.
