### PR TITLE
fix: correct password length validation and add custom error message

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserPostRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/UserPostRequest.java
@@ -32,7 +32,7 @@ public class UserPostRequest {
 
     @JsonProperty("password")
     @NotNull
-    @Size(min = 8, max = 200)
+    @Size(min = 8, max = 20, message = "Password must be between 8 and 20 characters.")
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
             message = "Password must contain uppercase, lowercase, digit, and special character.")


### PR DESCRIPTION
## Class:
UserPostRequest.java

## Method:
N/A (Validation annotation only)

## Issue:
The `@Size` annotation on the password field incorrectly allowed up to 200 characters,  
which conflicted with the `@Pattern` restriction (8–20 characters).  
Additionally, no user-friendly error message was provided for failed validation.

## Cause:
Initial validation configuration was too permissive and lacked clarity for users.

## Fix:
- Updated `@Size(max)` from `200` to `20` to match actual password rule
- Added custom error message to clearly describe the password length requirement

## Note:
This change ensures the validation behavior matches the intended password policy and improves feedback for users.
