### PR TITLE
feat: add password format validation to Password class

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/value/Password.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Password.java
@@ -7,6 +7,9 @@ public class Password {
     final String encodedPassword;
     private final int PASSWORD_LENGTH_MIN = 8;
     private final int PASSWORD_LENGTH_MAX = 20;
+    private final String REGEX =
+            "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{"
+                    + PASSWORD_LENGTH_MIN + "," + PASSWORD_LENGTH_MAX + "}$";
 
     private Password(String defaultPassword) throws IllegalArgumentException {
         if (defaultPassword.length() < PASSWORD_LENGTH_MIN) {
@@ -14,6 +17,9 @@ public class Password {
         }
         if (defaultPassword.length() > PASSWORD_LENGTH_MAX) {
             throw new IllegalArgumentException("Argument too long");
+        }
+        if (!defaultPassword.matches(REGEX)) {
+            throw new IllegalArgumentException("Not matched this password to regex");
         }
         encodedPassword = passwordEncoder.encode(defaultPassword);
 


### PR DESCRIPTION
## Class:
Password.java

## Method:
private Password(String defaultPassword)

## Issue:
The Password class previously lacked format validation logic, which allowed weak or structurally invalid passwords to be accepted if directly instantiated.

## Cause:
Password validation was only applied at the DTO level via annotations, which did not protect the domain layer from invalid construction.

## Fix:
Added internal validation logic in the Password class constructor using regular expression matching.

- Passwords must be 8–20 characters in length
- Must contain at least one lowercase letter, one uppercase letter, one digit, and one special character
- Throws `IllegalArgumentException` on invalid input

## Note:
This change ensures that all passwords created via the Password domain class are validated consistently, regardless of how they are constructed.  
This complements frontend and DTO-level validation by reinforcing the rules at the domain layer.
