### PR TITLE
fix: correct typo in method name (getEncordedPassword → getEncodedPassword)

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
@@ -53,14 +53,14 @@ public class UserRepository {
         final String sql =
                 "insert into users(name,photo,birthday,email,password) values(?,?,?,?,?)";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getPassword().getEncordedPassword());
+                user.getEmail(), user.getPassword().getEncodedPassword());
     }
 
     public int update(User user) {
         final String sql =
                 "update users set name=?,photo=?,birthday=?,email=?,password=? where id=?";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getPassword().getEncordedPassword(), user.getId());
+                user.getEmail(), user.getPassword().getEncodedPassword(), user.getId());
     }
 
     public int delete(int id) {

--- a/backend/src/main/java/com/calendar/milestone/model/value/Password.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Password.java
@@ -29,7 +29,7 @@ public class Password {
         return new Password(defaultPassword);
     }
 
-    public String getEncordedPassword() {
+    public String getEncodedPassword() {
         return encodedPassword;
     }
 


### PR DESCRIPTION
## Class:
Password.java and all referencing classes

## Method:
getEncodedPassword()

## Issue:
The getter method for the encoded password was misspelled as `getEncordedPassword`, leading to inconsistent naming and potential confusion.

## Cause:
Typographical error in the method name during initial implementation, and its usage was propagated to multiple locations.

## Fix:
- Renamed method `getEncordedPassword` → `getEncodedPassword` in `Password` class
- Updated all references across the codebase to use the corrected method name

## Note:
This is a non-functional refactor focused on improving code clarity and consistency.  
No business logic or behavior has been changed.
