### PR TITLE
chore: add unique constraint to email field in users table

### DIFF
--- a/backend/src/main/resources/db/migration/V1__create_users_tables.sql
+++ b/backend/src/main/resources/db/migration/V1__create_users_tables.sql
@@ -9,6 +9,7 @@ create table if not exists users(
     created_at datetime default current_timestamp not null,
     updated_at datetime default current_timestamp on update current_timestamp,
     deleted_at datetime default NULL,
+    unique (email),
     primary key(id)
 );
 


### PR DESCRIPTION
## Class:
V1__create_users_tables.sql

## Method:
N/A (DDL modification)

## Source:
Database migration file

## Issue:
The `email` field in the `users` table did not have a unique constraint, which could lead to duplicate email registration.

## Cause:
Initial schema definition lacked `UNIQUE` constraint on `email` despite expecting it to be a unique identifier.

## Fix:
Added `UNIQUE (email)` constraint to the `users` table schema definition.

## Note:
- Ensured semantic clarity and normalized design.
