### PR TITLE
feat: create Email class and add validation test

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/value/Email.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Email.java
@@ -1,0 +1,32 @@
+package com.calendar.milestone.model.value;
+
+public class Email {
+
+    private final String email;
+    private final int EMAIL_LENGTH_MIN = 6;
+    private final int EMAIL_LENGTH_MAX = 30;
+    private final String REGEX = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$";
+
+    private Email(String email) throws IllegalArgumentException {
+        if (email.length() < EMAIL_LENGTH_MIN) {
+            throw new IllegalArgumentException("emal too short. email length:" + email.length());
+        }
+        if (email.length() > EMAIL_LENGTH_MAX) {
+            throw new IllegalArgumentException("email too long. email length:" + email.length());
+        }
+        if (!email.matches(REGEX)) {
+            throw new IllegalArgumentException(
+                    "The email does not follow the regular expression. this time emal:" + email);
+        }
+        this.email = email;
+    }
+
+    public static Email of(String email) throws IllegalArgumentException {
+        return new Email(email);
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+}

--- a/backend/src/test/java/com/calendar/milestone/model/value/EmailTest.java
+++ b/backend/src/test/java/com/calendar/milestone/model/value/EmailTest.java
@@ -1,0 +1,38 @@
+package com.calendar.milestone.model.value;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EmailTest {
+
+    @Test
+    void validEmail_shouldCreateInstance() {
+        Email email = Email.of("user@example.com");
+        assertEquals("user@example.com", email.getEmail());
+    }
+
+    @Test
+    void tooShortEmail_shouldThrowException() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Email.of("a@b.c");
+        });
+        assertTrue(exception.getMessage().contains("too short"));
+    }
+
+    @Test
+    void tooLongEmail_shouldThrowException() {
+        String longEmail = "a".repeat(50) + "@example.com";
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Email.of(longEmail);
+        });
+        assertTrue(exception.getMessage().contains("too long"));
+    }
+
+    @Test
+    void invalidRegexEmail_shouldThrowException() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Email.of("not-an-email");
+        });
+        assertTrue(exception.getMessage().contains("regular expression"));
+    }
+}


### PR DESCRIPTION
## Class:
`Email`

## Method:
`Email.of()`

## Issue:
The email string required proper validation for length and format.

## Cause:
Previously, the email was handled as a plain `String`, which could allow invalid values to pass through the system unchecked.

## Fix:
- Created a dedicated `Email` class that performs validation logic in the constructor.
- Added unit test to ensure invalid email formats throw exceptions.

## Note:
- Enforces minimum and maximum length (6–30 characters)
- Regex requires domain suffix to be at least 2 characters long (`[a-zA-Z]{2,}`)
