### PR TITLE
refactor: rename getter methods for Email to avoid confusion

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/entity/User.java
+++ b/backend/src/main/java/com/calendar/milestone/model/entity/User.java
@@ -46,7 +46,7 @@ public class User {
         return birthday;
     }
 
-    public Email getEmail() {
+    public Email getEmailObject() {
         return email;
     }
 

--- a/backend/src/main/java/com/calendar/milestone/model/value/Email.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/Email.java
@@ -25,7 +25,7 @@ public class Email {
         return new Email(email);
     }
 
-    public String getEmail() {
+    public String getValue() {
         return email;
     }
 


### PR DESCRIPTION
## Overview
Refactored method names related to `Email` value object to eliminate ambiguity and improve code readability.

## Changes
- Renamed `User#getEmail()` to `getEmailObject()` to make it clear that it returns an `Email` object.
- Renamed `Email#getEmail()` to `getValue()` to follow the naming convention of value objects exposing their internal value.
- Updated usage throughout the service layer to reflect these new method names.

## Reason
Using the same method name `getEmail()` in both `User` and `Email` classes led to confusion and hard-to-read code, especially in `UserService`.  
This change improves clarity and maintains separation of responsibility between entity and value object layers.

## Note
No functional changes. This is a pure refactor for maintainability.
