### PR TITLE
refactor: update UserRepository to use Email value object and adjusted getter method

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.calendar.milestone.model.repository;
 
 
 import com.calendar.milestone.model.entity.User;
+import com.calendar.milestone.model.value.Email;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.jdbc.core.RowMapper;
@@ -30,7 +31,7 @@ public class UserRepository {
                 if (rs.getDate("birthday") != null) {
                     userMap.setBirthday(rs.getDate("birthday").toLocalDate());
                 }
-                userMap.setEmail(rs.getString("email"));
+                userMap.setEmail(Email.of(rs.getString("email")));
                 Timestamp timestampCreated = rs.getTimestamp("created_at");
                 Timestamp timestampUpdated = rs.getTimestamp("updated_at");
                 Timestamp timestampDeleted = rs.getTimestamp("deleted_at");
@@ -53,14 +54,15 @@ public class UserRepository {
         final String sql =
                 "insert into users(name,photo,birthday,email,password) values(?,?,?,?,?)";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getPassword().getEncodedPassword());
+                user.getEmailObject().getValue(), user.getPassword().getEncodedPassword());
     }
 
     public int update(User user) {
         final String sql =
                 "update users set name=?,photo=?,birthday=?,email=?,password=? where id=?";
         return jdbcTemplate.update(sql, user.getName(), user.getPhoto(), user.getBirthday(),
-                user.getEmail(), user.getPassword().getEncodedPassword(), user.getId());
+                user.getEmailObject().getValue(), user.getPassword().getEncodedPassword(),
+                user.getId());
     }
 
     public int delete(int id) {

--- a/backend/src/test/java/com/calendar/milestone/model/value/EmailTest.java
+++ b/backend/src/test/java/com/calendar/milestone/model/value/EmailTest.java
@@ -8,7 +8,7 @@ public class EmailTest {
     @Test
     void validEmail_shouldCreateInstance() {
         Email email = Email.of("user@example.com");
-        assertEquals("user@example.com", email.getEmail());
+        assertEquals("user@example.com", email.getValue());
     }
 
     @Test


### PR DESCRIPTION
## Class
`UserRepository`

## Method
- `insert(User user)`
- `update(User user)`
- `RowMapper<User>`

## Overview
Updated `UserRepository` to reflect the introduction of the `Email` value object:
- Used `Email.of(String)` when mapping from `ResultSet`
- Replaced `user.getEmail()` with `user.getEmailObject().getValue()` when binding parameters to SQL

These changes ensure consistent handling of email across the repository and enforce domain rules by leveraging the value object.

## Note
- Also updated the unit test (`EmailTest`) to match the new method name `getValue()` instead of `getEmail()`
- No behavior changes were made; this is purely a structural improvement
