### PR TITLE
feat: add ApiStatus enum for common API response handling

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiStatus.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiStatus.java
@@ -1,0 +1,29 @@
+package com.calendar.milestone.controller.dto.response.common;
+
+public enum ApiStatus {
+    OK(200,"Ok"),
+    CREATE(201,"Create"),
+    NO_CONTENT(204,"No Content"),
+    FORBIDDEN(403, "Forbidden"),
+    NOT_FOUND(404, "Not Found"),
+    METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    CONFLICT(409, "Conflict"),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error");
+    
+
+    final private int status;
+    final private String message;
+
+    ApiStatus(final int status,final String message){
+        this.status=status;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+    public String getMessage() {
+        return message;
+    }
+
+}


### PR DESCRIPTION
## Overview  
This PR introduces the `ApiStatus` enum to standardize response statuses in REST API design. Previously, response values such as `int 1` or `int 0` were used, making it difficult to clearly convey the result of an API operation.

## Motivation  
There was no unified structure for API responses, especially for update and create operations. By introducing a centralized enum for response status codes and messages, we can ensure consistent and meaningful responses across the system.

## Affected  
- Added a `common` package under `dto/response`
- Created `ApiStatus` enum to define shared HTTP status codes and messages

## Example  
```
controller/dto/response/common/
└── ApiStatus.java
```

## ✅ Is this PR safe?
- ✅ No behavioral changes (structure-only refactoring)
- ✅ Enum only: no logic changes or runtime impact
- ✅ Improves future maintainability and response readability