### PR TITLE
feat: add BAD_REQUEST and UNAUTHORIZED to ApiStatus enum for more accurate REST responses

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiStatus.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiStatus.java
@@ -4,6 +4,8 @@ public enum ApiStatus {
     OK(200,"Ok"),
     CREATE(201,"Create"),
     NO_CONTENT(204,"No Content"),
+    BAD_REQUEST(400,"Bad Request"),
+    UNAUTHORIZED(401,"Unauthorized"),
     FORBIDDEN(403, "Forbidden"),
     NOT_FOUND(404, "Not Found"),
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),


### PR DESCRIPTION

## Class:
ApiStatus

## Method:
(no specific method – enum values added)

## Overview:
Added two new enum constants `BAD_REQUEST` (400) and `UNAUTHORIZED` (401) to support more appropriate REST API responses for client errors and authentication failures.

## Note:
These statuses are useful when representing common HTTP error scenarios in RESTful API responses, such as invalid input or failed authentication.
