### PR TITLE
feat: add UserApiStatusResponse for standardizing user-related API responses

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/UserApiStatusResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/UserApiStatusResponse.java
@@ -1,0 +1,39 @@
+package com.calendar.milestone.controller.dto.response.user;
+
+import com.calendar.milestone.controller.dto.response.common.ApiStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public class UserApiStatusResponse {
+
+    @JsonProperty("statusCode")
+    @NotNull
+    private Integer statusCode;
+
+    @JsonProperty("statusMessage")
+    @NotNull
+    private String statusMessage;
+
+    public UserApiStatusResponse(final ApiStatus api) {
+        statusCode = api.getStatus();
+        statusMessage = api.getMessage();
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public void setStatusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+
+
+}


### PR DESCRIPTION
## Class:
UserApiStatusResponse

## Method:
Constructor + Getters/Setters

## Overview:
Created a new DTO class `UserApiStatusResponse` used for representing API responses to User-related POST/PUT requests.  
The class extracts `statusCode` and `statusMessage` from the shared `ApiStatus` enum to standardize API return formats.

## Note:
Useful when you want to unify success/failure response formats across different user-related endpoints without exposing sensitive data.
