### PR TITLE
feat: add RawPassword class for handling and verifying plain text passwords

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/value/RawPassword.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/RawPassword.java
@@ -1,0 +1,37 @@
+package com.calendar.milestone.model.value;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class RawPassword {
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final String rawPassword;
+    private final int PASSWORD_LENGTH_MIN = 8;
+    private final int PASSWORD_LENGTH_MAX = 20;
+    private final String REGEX =
+            "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{"
+                    + PASSWORD_LENGTH_MIN + "," + PASSWORD_LENGTH_MAX + "}$";
+
+
+    private RawPassword(final String rawPassword) {
+        if (rawPassword.length() < PASSWORD_LENGTH_MIN) {
+            throw new IllegalArgumentException("Argument too short");
+        }
+        if (rawPassword.length() > PASSWORD_LENGTH_MAX) {
+            throw new IllegalArgumentException("Argument too long");
+        }
+        if (!rawPassword.matches(REGEX)) {
+            throw new IllegalArgumentException("Not matched this password to regex");
+        }
+        this.rawPassword = rawPassword;
+    }
+
+    public static RawPassword of(final String rawPassword) {
+        return new RawPassword(rawPassword);
+    }
+
+    public boolean passwordMatch(final String passwordEncoded) {
+        return passwordEncoder.matches(rawPassword, passwordEncoded);
+    }
+
+
+}


### PR DESCRIPTION
## Overview
Added `RawPassword` class to handle raw input passwords securely and verify them against stored encoded passwords.

## Motivation
- Needed a clean and testable way to verify that the password sent from the frontend matches the stored encoded password.
- Avoided using `String` directly for raw passwords to encapsulate validation and prevent careless exposure.
- No getters/setters are provided to enhance security and reduce risk of leakage.

## Affected
- New file: `RawPassword.java` (in `model/value`)

## Example
```java
RawPassword raw = RawPassword.of("userInputPassword");
if (raw.passwordMatch(storedEncodedPassword)) {
    // proceed with auth
}
