### PR TITLE
refactor: remove @NotNull from id in UserPasswordChangeRequest

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/user/UserPasswordChangeRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/user/UserPasswordChangeRequest.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.Size;
 public class UserPasswordChangeRequest {
 
     @JsonProperty("id")
-    @NotNull
     private Integer id;
 
     @JsonProperty("email")


### PR DESCRIPTION
## Class:
`UserPasswordChangeRequest`

## Field:
`id`

## Overview:
Removed `@NotNull` annotation from the `id` field in `UserPasswordChangeRequest`.

## Motivation:
The `id` is provided via the URI path parameter in API calls, not in the request body.  
Marking it as `@NotNull` leads to unnecessary validation failures even when the request is valid.

## Note:
- This change ensures the DTO reflects the actual usage pattern of the API.
- No functional behavior is altered. It's a structural fix to prevent false validation errors.
