### PR TITLE
feat: add selectLoginUserId method in UserRepository to retrieve userID by email

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/UserRepository.java
@@ -4,6 +4,7 @@ package com.calendar.milestone.model.repository;
 import com.calendar.milestone.model.entity.User;
 import com.calendar.milestone.model.value.Email;
 import com.calendar.milestone.model.value.Password;
+import com.calendar.milestone.model.value.UserId;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.jdbc.core.RowMapper;
@@ -49,6 +50,17 @@ public class UserRepository {
             }
         }, id);
         return user;
+    }
+
+    public UserId selectLoginUserId(Email email) {
+        final String sql = "select id from users where email=?";
+        UserId userId = jdbcTemplate.queryForObject(sql, new RowMapper<UserId>() {
+            @Override
+            public UserId mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return UserId.of(rs.getInt("id"));
+            }
+        }, email.getValue());
+        return userId;
     }
 
     public String findPassword(Email email) {


### PR DESCRIPTION
## Class:
`UserRepository`

## Method:
`selectLoginUserId(Email email): UserId`

## Overview:
Added a new method `selectLoginUserId` to `UserRepository`.  
This method retrieves only the `id` of the user matching the given email.

## Motivation:
Fetching the entire `User` entity during authentication is not necessary and could pose a security risk.  
Instead, this method returns only the user ID wrapped in the custom `UserId` value object, ensuring:
- Minimal data exposure
- Safer handling of sensitive user information

## Note:
This method is intended for use in login flows where only the `userId` is required after authentication succeeds.
