### PR TITLE
refactor: change JwtPayload constructor argument from User to UserId

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/value/JwtPayload.java
+++ b/backend/src/main/java/com/calendar/milestone/model/value/JwtPayload.java
@@ -1,16 +1,16 @@
 package com.calendar.milestone.model.value;
 
-import com.calendar.milestone.model.entity.User;
+
 
 public class JwtPayload {
     private final int payloadId;
 
-    private JwtPayload(final User user) {
-        payloadId = user.getId();
+    private JwtPayload(final UserId userId) {
+        payloadId = userId.getValue();
     }
 
-    public static JwtPayload of(final User user) {
-        return new JwtPayload(user);
+    public static JwtPayload of(final UserId userId) {
+        return new JwtPayload(userId);
     }
 
     public String getPayloadId() {


### PR DESCRIPTION
## Class:
`JwtPayload`

## Method:
- `JwtPayload.of(...)`  
- `getPayloadId()`

## Overview:
This PR refactors the `JwtPayload` class to accept a `UserId` value object instead of the full `User` entity.

By doing so:
- We **reduce security risk** by avoiding exposure of the full `User` object.
- We **maintain a clean domain boundary**, ensuring entities are not leaked into value layers unnecessarily.
- The logic remains unchanged—only the input type has been adjusted to favor safer, domain-specific abstraction.

## Note:
- This change improves domain encapsulation by using a `UserId` value object.
- The `payloadId` is still extracted via `userId.getValue()`, keeping behavior intact.