### PR TITLE
feat: add JwtSigningKeyConfig to handle HMAC key generation for JWT

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/config/JwtSigningKeyConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/model/config/JwtSigningKeyConfig.java
@@ -1,0 +1,18 @@
+package com.calendar.milestone.model.config;
+
+import javax.crypto.SecretKey;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+
+public class JwtSigningKeyConfig {
+
+    private final SecretKey key;
+
+    public JwtSigningKeyConfig(String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public SecretKey getKey() {
+        return key;
+    }
+}


### PR DESCRIPTION
## Class:
`JwtSigningKeyConfig`

## Method:
- Constructor: `JwtSigningKeyConfig(String secret)`
- Getter: `getKey()`

## Overview:
This class was introduced to encapsulate the logic for generating an HMAC signing key from a secret string.  
The `JwtUtility` class uses this when calling `signWith(...)` during token creation.

## Note:
- Uses `Keys.hmacShaKeyFor(...)` from `io.jsonwebtoken.security.Keys`
- Secret is injected via application config and encoded as `SecretKey` using UTF-8
- This avoids hardcoding cryptographic logic inside utility classes
