### PR TITLE
feat: add DiConfig class for centralizing dependency injection setup

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/config/DiConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/model/config/DiConfig.java
@@ -1,0 +1,14 @@
+package com.calendar.milestone.model.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DiConfig {
+
+    @Bean
+    public JwtSigningKeyConfig jwtSigningKeyConfig(@Value("${jwt.secret}") final String secret) {
+        return new JwtSigningKeyConfig(secret);
+    }
+}


### PR DESCRIPTION
## Class:
`DiConfig`

## Method:
- `jwtSigningKeyConfig(String secret)`

## Overview:
Introduced `DiConfig` as a configuration class responsible for centralizing dependency injection definitions using `@Configuration` and `@Bean`.  
This class currently provides a `JwtSigningKeyConfig` bean by injecting the `jwt.secret` value from environment variables.

## Note:
- `@Value("${jwt.secret}")` injects secret from `.env` or application properties
- Future DI beans should be defined here to keep injection logic centralized and maintainable
- Part of the ongoing effort to cleanly separate configuration from business logic
