### PR TITLE
feat: add signWith using JwtSigningKeyConfig to JwtUtility for token encryption

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/utility/JwtUtility.java
+++ b/backend/src/main/java/com/calendar/milestone/model/utility/JwtUtility.java
@@ -1,20 +1,25 @@
 package com.calendar.milestone.model.utility;
 
 import java.util.Date;
+import com.calendar.milestone.model.config.JwtSigningKeyConfig;
 import com.calendar.milestone.model.value.JwtPayload;
 import io.jsonwebtoken.Jwts;
 
 public class JwtUtility {
-    static private final int ONE_HOUR = 3600 * 1000;
-    final private String token;
+    private static final int ONE_HOUR = 3600 * 1000;
+    private final String token;
+    private final JwtSigningKeyConfig key;
 
-    private JwtUtility(final JwtPayload jwtPayload) {
+
+    private JwtUtility(final JwtSigningKeyConfig key, final JwtPayload jwtPayload) {
+        this.key = key;
         token = Jwts.builder().subject(jwtPayload.getPayloadId()).issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + ONE_HOUR)).compact();
+                .expiration(new Date(System.currentTimeMillis() + ONE_HOUR)).signWith(key.getKey())
+                .compact();
     }
 
-    public static JwtUtility of(final JwtPayload jwtPayload) {
-        return new JwtUtility(jwtPayload);
+    public static JwtUtility of(final JwtSigningKeyConfig key, final JwtPayload jwtPayload) {
+        return new JwtUtility(key, jwtPayload);
     }
 
     public String getToken() {


### PR DESCRIPTION
## Class:
`JwtUtility`

## Method:
- `JwtUtility.of(JwtSigningKeyConfig key, JwtPayload payload)`
- `getToken()`

## Overview:
Enhanced the `JwtUtility` class to include token signing using the provided `JwtSigningKeyConfig`.  
By injecting the secret key via `JwtSigningKeyConfig`, the token is now signed using the `signWith(...)` method, improving security and aligning with JWT best practices.

## Note:
- `JwtSigningKeyConfig` now must be passed to `JwtUtility.of(...)`
- Signing algorithm used is determined by the SecretKey generated (e.g. HMAC SHA-512)
- Token now includes `iat`, `exp`, and a proper signature
