### PR TITLE
feat: implement ApiResponse interface in UserApiStatusResponse for unified API response handling

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/UserApiStatusResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/UserApiStatusResponse.java
@@ -1,17 +1,15 @@
 package com.calendar.milestone.controller.dto.response.user;
 
+import com.calendar.milestone.controller.dto.response.common.ApiResponse;
 import com.calendar.milestone.controller.dto.response.common.ApiStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
 
-public class UserApiStatusResponse {
+public class UserApiStatusResponse implements ApiResponse {
 
     @JsonProperty("statusCode")
-    @NotNull
     private Integer statusCode;
 
     @JsonProperty("statusMessage")
-    @NotNull
     private String statusMessage;
 
     public UserApiStatusResponse(final ApiStatus api) {


### PR DESCRIPTION
## Class:
`UserApiStatusResponse`

## Method:
- N/A (Interface implementation)

## Overview:
Implemented the `ApiResponse` interface in `UserApiStatusResponse` to unify response handling across the application.  
This enables consistent treatment of successful and error responses, particularly in cases where only status information is needed.

## Note:
- Removed unnecessary `@NotNull` annotations from status fields (validation not required for fixed enum-based values)
- Now conforms to the common `ApiResponse` interface used throughout the system

