### PR TITLE
chore: add .env to .gitignore to prevent committing sensitive config

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env


### PR DESCRIPTION
## Class:
N/A

## Method:
N/A

## Overview:
Added `.env` to `.gitignore` to prevent accidental commits of environment-specific configuration and credentials.

## Note:
- A new `.env` file will be used to manage sensitive or environment-specific values
- Ensures sensitive info like DB passwords, API keys, and signing secrets aren’t pushed to version control
- Reminder: don’t be that person who leaks credentials to GitHub and becomes a case study :)
