### PR TITLE
feat: create JwtToken value object for token parsing and format validation

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/security/token/JwtToken.java
+++ b/backend/src/main/java/com/calendar/milestone/security/token/JwtToken.java
@@ -1,0 +1,40 @@
+package com.calendar.milestone.security.token;
+
+public class JwtToken {
+    private final String token;
+    private static final int EXPECTED_DOT_COUNT = 2;
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+    private JwtToken(final String token) throws IllegalArgumentException {
+
+        final String cleanToken = cloudTokenCheck(token);
+        if (!tokenCheck(cleanToken)) {
+            throw new IllegalArgumentException("Token period mismatch");
+        }
+        this.token = cleanToken;
+    }
+
+    private boolean tokenCheck(String token) {
+        final int keyWord = (int) token.chars().filter(cha -> cha == '.').count();
+        if (keyWord != EXPECTED_DOT_COUNT) {
+            return false;
+        }
+        return true;
+    }
+
+    private String cloudTokenCheck(String token) {
+        if (token.startsWith(BEARER_PREFIX))
+            return token.substring(BEARER_PREFIX_LENGTH);
+        return token;
+    }
+
+    public static JwtToken of(final String token) throws IllegalArgumentException {
+        return new JwtToken(token);
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+}


### PR DESCRIPTION
## Class:
`JwtToken`

## Overview:
This PR introduces the `JwtToken` value object, responsible for managing JWT string formatting and validation during both token generation and reception.

- Used when **creating new JWTs** or **receiving existing tokens** (e.g., from clients or other services)
- Strips the optional "Bearer " prefix (e.g., from Authorization headers)
- Validates structural integrity by checking for exactly 2 dot (`.`) separators
- Provides a static factory method `JwtToken.of(String)` for controlled and safe instantiation
- Exposes the sanitized JWT string via `getToken()`

## Note:
- Designed for bi-directional usage: **token generation and input validation**
- Signature verification is not handled here—it is expected to be processed in a dedicated security layer