### PR TITLE
refactor: restructure JwtToken creation with separated validation paths

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/security/token/JwtToken.java
+++ b/backend/src/main/java/com/calendar/milestone/security/token/JwtToken.java
@@ -1,36 +1,47 @@
 package com.calendar.milestone.security.token;
 
+
 public class JwtToken {
     private final String token;
     private static final int EXPECTED_DOT_COUNT = 2;
     private static final String BEARER_PREFIX = "Bearer ";
     private static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
 
+    private JwtToken(final JwtTokenGenerator token) throws IllegalArgumentException {
+        final String rawToken = token.getRawToken();
+        this.token = validDotCount(rawToken);
+    }
+
     private JwtToken(final String token) throws IllegalArgumentException {
-
-        final String cleanToken = cloudTokenCheck(token);
-        if (!tokenCheck(cleanToken)) {
-            throw new IllegalArgumentException("Token period mismatch");
-        }
-        this.token = cleanToken;
+        final String rawToken = clientTokenCheck(token);
+        this.token = validDotCount(rawToken);
     }
 
-    private boolean tokenCheck(String token) {
-        final int keyWord = (int) token.chars().filter(cha -> cha == '.').count();
-        if (keyWord != EXPECTED_DOT_COUNT) {
-            return false;
+    private String validDotCount(final String token) {
+        final int dotCount = (int) token.chars().filter(cha -> cha == '.').count();
+        if (dotCount != EXPECTED_DOT_COUNT) {
+            throw new IllegalArgumentException(
+                    "The token format is invalid. Expected 2 periods (JWT format).");
         }
-        return true;
-    }
-
-    private String cloudTokenCheck(String token) {
-        if (token.startsWith(BEARER_PREFIX))
-            return token.substring(BEARER_PREFIX_LENGTH);
         return token;
     }
 
-    public static JwtToken of(final String token) throws IllegalArgumentException {
+    private String clientTokenCheck(final String token) throws IllegalArgumentException {
+        if (!token.startsWith(BEARER_PREFIX)) {
+            throw new IllegalArgumentException(
+                    "The token format is invalid. Expected a Bearer token.");
+        }
+        return token.substring(BEARER_PREFIX_LENGTH);
+
+    }
+
+    public static JwtToken fromGenerator(final JwtTokenGenerator token)
+            throws IllegalArgumentException {
         return new JwtToken(token);
+    }
+
+    public static JwtToken fromClientToken(final String rawToken) throws IllegalArgumentException {
+        return new JwtToken(rawToken);
     }
 
     public String getToken() {


### PR DESCRIPTION
## Class:
`JwtToken`

## Method:
- `JwtToken(JwtTokenGenerator token)`
- `JwtToken(String token)`
- `validDotCount(String)`
- `clientTokenCheck(String)`
- `fromGenerator(...)`
- `fromClientToken(...)`

## Overview:
This PR refactors the `JwtToken` class to improve responsibility separation and validation clarity.

### Key changes:
- Introduced **distinct constructor logic** for tokens generated internally (`JwtTokenGenerator`) and tokens received from client-side requests (`String`).
- Centralized dot-count validation in `validDotCount`, which now throws a descriptive `IllegalArgumentException` if the format is invalid.
- Added clear and explicit error messaging for both invalid JWT structure and non-Bearer client tokens.
- Removed legacy methods like `cloudTokenCheck` and `tokenCheck`, which were overly generic and duplicated logic.

## Motivation:
This change improves:
- **Clarity** of token source (generator vs client)
- **Validation accuracy** with meaningful exceptions
- **Maintainability** by reducing duplicate logic
