### PR TITLE
refactor: enforce type-safe constructor for JwtToken and adjust factory usage

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/security/token/JwtTokenGenerator.java
+++ b/backend/src/main/java/com/calendar/milestone/security/token/JwtTokenGenerator.java
@@ -7,13 +7,21 @@ import io.jsonwebtoken.Jwts;
 
 public class JwtTokenGenerator {
     private static final int ONE_HOUR = 3600 * 1000;
+    private final String token;
 
-    public static JwtToken generatoToken(final JwtSigningKeyConfig key,
+    private JwtTokenGenerator(final String token) {
+        this.token = token;
+    }
+
+    public static JwtToken generateToken(final JwtSigningKeyConfig key,
             final JwtPayload jwtPayload) {
-
         String generatoToken = Jwts.builder().subject(jwtPayload.getPayloadId())
                 .issuedAt(new Date()).expiration(new Date(System.currentTimeMillis() + ONE_HOUR))
                 .signWith(key.getKey()).compact();
-        return JwtToken.of(generatoToken);
+        return JwtToken.fromGenerator(new JwtTokenGenerator(generatoToken));
+    }
+
+    public String getRawToken() {
+        return token;
     }
 }


### PR DESCRIPTION
## Class:
`JwtTokenGenerator`

## Method:
- `generateToken(...)`
- `getRawToken()`

## Overview:
This PR introduces structural changes to `JwtTokenGenerator` to support type-safe JWT creation and delegation to `JwtToken`.

- Added a private constructor to encapsulate the raw token string.

- Added `getRawToken()` method to expose the internal token string to consumers like `JwtToken`.

## Note:
- This refactor allows `JwtTokenGenerator` to act as a trusted token source.
- `JwtToken.fromGenerator()` can now enforce validation and maintain clear token creation responsibility.