### PR TITLE
feat(config): add JwtDecoder and AuthenticationManager beans for JwtAuthenticationFilter

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/config/DiConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/model/config/DiConfig.java
@@ -3,6 +3,11 @@ package com.calendar.milestone.model.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 
 @Configuration
 public class DiConfig {
@@ -10,5 +15,15 @@ public class DiConfig {
     @Bean
     public JwtSigningKeyConfig jwtSigningKeyConfig(@Value("${jwt.secret}") final String secret) {
         return new JwtSigningKeyConfig(secret);
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder(final JwtSigningKeyConfig jwtSigningKeyConfig) {
+        return NimbusJwtDecoder.withSecretKey(jwtSigningKeyConfig.getKey()).build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticatorManager(final JwtDecoder jwtDecoder) {
+        return new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
     }
 }


### PR DESCRIPTION
## Class:
`DiConfig`

## Method:
N/A (new bean definitions)

## Overview:
This PR adds two new beans to the `DiConfig` class:
- **JwtDecoder**: Configured with the application's secret key via `NimbusJwtDecoder`
- **AuthenticationManager**: Configured as a `ProviderManager` with a `JwtAuthenticationProvider`

These beans are introduced to support the upcoming `JwtAuthenticationFilter` implementation.  
By registering them in the Spring context, we avoid manual instantiation within the filter and promote cleaner dependency injection.

## Note:
- `JwtDecoder` uses `JwtSigningKeyConfig` for key retrieval.
- `AuthenticationManager` is wired with the `JwtAuthenticationProvider` using the injected `JwtDecoder`.
- No existing functionality is affected; this is preparatory for new authentication features.
