### PR TITLE
fix: improve JwtAuthenticationFilter with logging and Jwt principal validation

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/calendar/milestone/security/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.calendar.milestone.security.filter;
 
 import java.io.IOException;
 import org.springframework.web.filter.OncePerRequestFilter;
+import com.calendar.milestone.infrastructure.MilestoneLogger;
 import com.calendar.milestone.security.token.JwtToken;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -13,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -29,8 +31,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
+        MilestoneLogger.info("Filterの処理開始");
         final String clientToken = request.getHeader("Authorization");
         if (clientToken == null || !clientToken.startsWith("Bearer ")) {// Bearer認証であることの確認
+            MilestoneLogger.info("Filter処理対象外。");
             filterChain.doFilter(request, response);
             return;
         }
@@ -38,12 +42,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         BearerTokenAuthenticationToken bearerToken =
                 new BearerTokenAuthenticationToken(token.getToken());
         try {
-            // 認証済みユーザーをsecurityContextにset
+            // デコード後に認証内容がJwtになっていない場合セキュリティリスクがあるためエラーとする
             final Authentication authentication = authenticationManager.authenticate(bearerToken);
+            if (!(authentication.getPrincipal() instanceof Jwt)) {
+                MilestoneLogger.warn("Jwt形式と不一致のため処理不可");
+                throw new RuntimeException("this token is mismath.");
+            }
             final SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(authentication);
             SecurityContextHolder.setContext(context);
         } catch (AuthenticationException authenticationException) {
+            MilestoneLogger.warn("認証処理失敗");
             SecurityContextHolder.clearContext();
             authenticationEntryPoint.commence(request, response, authenticationException);
             return;


### PR DESCRIPTION

## Overview
Refactored `JwtAuthenticationFilter` to improve security and observability.  
Added detailed logging and explicit `Jwt` type validation for the authentication result.

## Motivation
- Needed to log filter processing steps for easier debugging.
- Ensure authenticated principal is strictly a `Jwt` object to prevent unexpected or insecure behavior.

## Affected
- **Modified class**: `com.calendar.milestone.security.filter.JwtAuthenticationFilter`
  - Added `MilestoneLogger` for filter start, skip, and error cases.
  - Added `instanceof Jwt` check after authentication.
  - Improved error handling with clear logging when authentication fails.
  - Retained SecurityContext population on successful authentication.

## Example
```java
if (!(authentication.getPrincipal() instanceof Jwt)) {
    MilestoneLogger.warn("Jwt形式と不一致のため処理不可");
    throw new RuntimeException("this token is mismath.");
}
