### PR TITLE
feat(security): integrate JwtAuthenticationFilter and refine SecurityConfig

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/config/SecurityConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/config/SecurityConfig.java
@@ -2,16 +2,41 @@ package com.calendar.milestone.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import com.calendar.milestone.security.filter.JwtAuthenticationFilter;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            final AuthenticationManager authenticationManager,
+            final AuthenticationEntryPoint authenticationEntryPoint) {
+        return new JwtAuthenticationFilter(authenticationManager, authenticationEntryPoint);
+    }
+
+    // patternにマッチする場合はfilterを通過するように設定をする必要がある。
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http.securityMatcher("/users/**").csrf(csrf -> csrf.disable())
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.requestMatchers("/users/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new BearerTokenAuthenticationEntryPoint();
     }
 }


### PR DESCRIPTION

## Overview
Updated `SecurityConfig` to integrate JWT authentication:
- Added `JwtAuthenticationFilter` bean
- Applied stateless session policy
- Configured `SecurityFilterChain` to include JWT filter
- Added `AuthenticationEntryPoint` with `BearerTokenAuthenticationEntryPoint`

## Motivation
Enhance security configuration by enabling JWT-based authentication.  
This extends the previous minimal `SecurityConfig` into a more realistic base for request handling.

## Affected
- `SecurityConfig` class now includes filter chain, entry point, and session management.

## Note
- `/users/**` is currently configured as `permitAll`.  
  → This is temporary and will require refinement (e.g., `POST /users` only permitAll, other user endpoints authenticated).  
- Additional URL patterns and error handling will be added later.
