### PR TITLE
refactor(config): move DiConfig to config package and fix JwtDecoder algorithm

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/config/DiConfig.java
+++ b/backend/src/main/java/com/calendar/milestone/config/DiConfig.java
@@ -1,15 +1,19 @@
-package com.calendar.milestone.model.config;
+package com.calendar.milestone.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+import com.calendar.milestone.model.config.JwtSigningKeyConfig;
 
 @Configuration
+@EnableWebSecurity
 public class DiConfig {
 
     @Bean
@@ -19,9 +23,12 @@ public class DiConfig {
 
     @Bean
     public JwtDecoder jwtDecoder(final JwtSigningKeyConfig jwtSigningKeyConfig) {
-        return NimbusJwtDecoder.withSecretKey(jwtSigningKeyConfig.getKey()).build();
+        // 64バイト以上のアルゴリズムでトークン発行をしているためデコード側でも対応するものを設定(HS512)
+        return NimbusJwtDecoder.withSecretKey(jwtSigningKeyConfig.getKey())
+                .macAlgorithm(MacAlgorithm.HS512).build();
     }
 
+    // JwtAuthenticationProviderにてクレームセットを返している。
     @Bean
     public AuthenticationManager authenticatorManager(final JwtDecoder jwtDecoder) {
         return new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));


### PR DESCRIPTION
## Overview
- Moved `DiConfig` from `model/config` to `config` package
- Updated `JwtDecoder` to explicitly use `HS512` algorithm
- Added `@EnableWebSecurity` annotation to configuration

## Motivation
- Package placement of `DiConfig` under `model/config` was inappropriate, since it is an application-level configuration rather than a domain model concern.
- Without explicitly setting the decode algorithm, JWT validation was failing. This update aligns the decoder with the HS512 algorithm used during token generation.

## Affected
- `DiConfig` relocated from `model/config` → `config`
- Token decoding stabilized with fixed algorithm configuration

## Note
- Further refactoring will likely be required to avoid `DiConfig` becoming a “god class” as more beans are added.  
  In the future, responsibility should be split into multiple config classes 
