### PR TITLE
refactor: rename goal date field to dueDate

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/goal/GoalRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/goal/GoalRequest.java
@@ -11,7 +11,7 @@ public class GoalRequest {
     @JsonProperty("id")
     private int id;
 
-    @JsonProperty("user_id")
+    @JsonProperty("userId")
     private int userId;
 
     @JsonProperty("title")
@@ -24,9 +24,9 @@ public class GoalRequest {
     @Size(max = 150)
     private String content;
 
-    @JsonProperty("date")
+    @JsonProperty("dueDate")
     @NotNull
-    private LocalDate date;
+    private LocalDate dueDate;
 
     public GoalRequest() {}
 
@@ -46,8 +46,8 @@ public class GoalRequest {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public void setId(int id) {
@@ -66,7 +66,7 @@ public class GoalRequest {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 }

--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/goal/GoalResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/goal/GoalResponse.java
@@ -26,17 +26,17 @@ public class GoalResponse {
     @Size(max = 150)
     private String content;
 
-    @JsonProperty("date")
+    @JsonProperty("dueDate")
     @NotNull
-    private LocalDate date;
+    private LocalDate dueDate;
 
-    @JsonProperty("created_at")
+    @JsonProperty("createdAt")
     private LocalDateTime createdAt;
 
-    @JsonProperty("updated_at")
+    @JsonProperty("updatedAt")  
     private LocalDateTime updatedAt;
 
-    @JsonProperty("deleted_at")
+    @JsonProperty("deletedAt")
     private LocalDateTime deletedAt;
 
     public GoalResponse() {}
@@ -57,8 +57,8 @@ public class GoalResponse {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -89,8 +89,8 @@ public class GoalResponse {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {

--- a/backend/src/main/java/com/calendar/milestone/model/entity/Goal.java
+++ b/backend/src/main/java/com/calendar/milestone/model/entity/Goal.java
@@ -8,19 +8,20 @@ public class Goal {
     private int userId;
     private String title;
     private String content;
-    private LocalDate date;
+    private LocalDate dueDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
 
     public Goal(final int id, final int userId, final String title, final String content,
-            final LocalDate date) {
+            final LocalDate dueDate) {
         this.id = id;
         this.userId = userId;
         this.title = title;
         this.content = content;
-        this.date = date;
+        this.dueDate = dueDate;
+    // TODO:add column completed_at(completed flag)
     }
 
     public Goal() {}
@@ -41,8 +42,8 @@ public class Goal {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -73,8 +74,8 @@ public class Goal {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {

--- a/backend/src/main/java/com/calendar/milestone/model/repository/GoalRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/GoalRepository.java
@@ -29,7 +29,7 @@ public class GoalRepository {
                 goalMap.setUserId(rs.getInt("user_id"));
                 goalMap.setTitle(rs.getString("title"));
                 goalMap.setContent(rs.getString("content"));
-                goalMap.setDate(rs.getDate("date").toLocalDate());
+                goalMap.setDueDate(rs.getDate("due_date").toLocalDate());
                 Timestamp timestamp_created = rs.getTimestamp("created_at");
                 Timestamp timestamp_updated = rs.getTimestamp("updated_at");
                 Timestamp timestamp_deleted = rs.getTimestamp("deleted_at");
@@ -49,14 +49,14 @@ public class GoalRepository {
     }
 
     public int insert(Goal goal) {
-        final String sql = "insert into goals(user_id,title,content,date) values(?,?,?,?)";
+        final String sql = "insert into goals(user_id,title,content,due_date) values(?,?,?,?)";
         return jdbcTemplate.update(sql, goal.getUserId(), goal.getTitle(), goal.getContent(),
-                goal.getDate());
+                goal.getDueDate());
     }
 
     public int update(Goal goal) {
-        final String sql = "update goals set title=?,content=?,date=? where id=?";
-        return jdbcTemplate.update(sql, goal.getTitle(), goal.getContent(), goal.getDate(),
+        final String sql = "update goals set title=?,content=?,due_date=? where id=?";
+        return jdbcTemplate.update(sql, goal.getTitle(), goal.getContent(), goal.getDueDate(),
                 goal.getId());
     }
 

--- a/backend/src/main/java/com/calendar/milestone/model/service/GoalService.java
+++ b/backend/src/main/java/com/calendar/milestone/model/service/GoalService.java
@@ -22,7 +22,7 @@ public class GoalService {
         goalResponse.setUserId(goal.getUserId());
         goalResponse.setTitle(goal.getTitle());
         goalResponse.setContent(goal.getContent());
-        goalResponse.setDate(goal.getDate());
+        goalResponse.setDueDate(goal.getDueDate());
         goalResponse.setCreatedAt(goal.getCreatedAt());
         if (goal.getUpdatedAt() != null) {
             goalResponse.setUpdatedAt(goal.getUpdatedAt());
@@ -37,7 +37,7 @@ public class GoalService {
         Goal goal = goalRepository.select(goalRequest.getId());
         goal.setTitle(goalRequest.getTitle());
         goal.setContent(goalRequest.getContent());
-        goal.setDate(goalRequest.getDate());
+        goal.setDueDate(goalRequest.getDueDate());
         return goal;
     }
 
@@ -47,7 +47,7 @@ public class GoalService {
         goal.setUserId(goalRequest.getUserId());
         goal.setTitle(goalRequest.getTitle());
         goal.setContent(goalRequest.getContent());
-        goal.setDate(goalRequest.getDate());
+        goal.setDueDate(goalRequest.getDueDate());
         return goalRepository.insert(goal);
     }
 


### PR DESCRIPTION
Renamed the goal date field to dueDate to clarify that it represents the goal deadline.
This avoids ambiguity with other date-related fields that may be added in the future.