### PR TITLE
refactor: standardize milestone API field naming

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/milestone/MilestoneRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/milestone/MilestoneRequest.java
@@ -13,7 +13,7 @@ public class MilestoneRequest {
     @JsonProperty("id")
     private Integer id;
 
-    @JsonProperty("goal_id")
+    @JsonProperty("goalId")
     private int goalId;
 
     @JsonProperty("title")
@@ -26,9 +26,9 @@ public class MilestoneRequest {
     @Size(max = 150)
     private String content;
 
-    @JsonProperty("date")
+    @JsonProperty("dueDate")
     @NotNull
-    private LocalDate date;
+    private LocalDate dueDate;
 
     public MilestoneRequest() {}
 
@@ -48,8 +48,8 @@ public class MilestoneRequest {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public void setId(int id) {
@@ -68,8 +68,8 @@ public class MilestoneRequest {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 
 }

--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/milestone/MilestoneResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/milestone/MilestoneResponse.java
@@ -13,7 +13,7 @@ public class MilestoneResponse {
     @JsonProperty("id")
     private Integer id;
 
-    @JsonProperty("goal_id")
+    @JsonProperty("goalId")
     private Integer goalId;
 
     @JsonProperty("title")
@@ -26,17 +26,17 @@ public class MilestoneResponse {
     @Size(max = 150)
     private String content;
 
-    @JsonProperty("date")
+    @JsonProperty("dueDate")
     @NotNull
-    private LocalDate date;
+    private LocalDate dueDate;
 
-    @JsonProperty("created_at")
+    @JsonProperty("createdAt")
     private LocalDateTime createdAt;
 
-    @JsonProperty("updated_at")
+    @JsonProperty("updatedAt")
     private LocalDateTime updatedAt;
 
-    @JsonProperty("deleted_at")
+    @JsonProperty("deletedAt")
     private LocalDateTime deletedAt;
 
     public MilestoneResponse() {}
@@ -57,8 +57,8 @@ public class MilestoneResponse {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -89,8 +89,8 @@ public class MilestoneResponse {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {
@@ -104,6 +104,4 @@ public class MilestoneResponse {
     public void setDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }
-
-
 }

--- a/backend/src/main/java/com/calendar/milestone/model/entity/Milestone.java
+++ b/backend/src/main/java/com/calendar/milestone/model/entity/Milestone.java
@@ -9,18 +9,19 @@ public class Milestone {
     private int goalId;
     private String title;
     private String content;
-    private LocalDate date;
+    private LocalDate dueDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
     public Milestone(final int id, final int goalId, final String title, final String content,
-            final LocalDate date) {
+            final LocalDate dueDate) {
         this.id = id;
         this.goalId = goalId;
         this.title = title;
         this.content = content;
-        this.date = date;
+        this.dueDate = dueDate;
+    // TODO:add column completed_at(completed flag)
     }
 
     public Milestone() {}
@@ -41,8 +42,8 @@ public class Milestone {
         return content;
     }
 
-    public LocalDate getDate() {
-        return date;
+    public LocalDate getDueDate() {
+        return dueDate;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -73,8 +74,8 @@ public class Milestone {
         this.content = content;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {

--- a/backend/src/main/java/com/calendar/milestone/model/repository/MilestoneRepository.java
+++ b/backend/src/main/java/com/calendar/milestone/model/repository/MilestoneRepository.java
@@ -18,6 +18,7 @@ public class MilestoneRepository {
     }
 
     public Milestone select(int id) {
+        // TODO:add column completed_at(completed flag)
         String sql = "select * from milestone where id=?";
         Milestone milestone = jdbcTemplate.queryForObject(sql, new RowMapper<Milestone>() {
             public Milestone mapRow(ResultSet rs, int rouNum) throws SQLException {
@@ -26,7 +27,7 @@ public class MilestoneRepository {
                 existMilestone.setGoalId(rs.getInt("goal_id"));
                 existMilestone.setTitle(rs.getString("title"));
                 existMilestone.setContent(rs.getString("content"));
-                existMilestone.setDate(rs.getDate("date").toLocalDate());
+                existMilestone.setDueDate(rs.getDate("due_date").toLocalDate());
                 Timestamp timestampCreated = rs.getTimestamp("created_at");
                 Timestamp timestampUpdated = rs.getTimestamp("updated_at");
                 Timestamp timestampDeleted = rs.getTimestamp("deleted_at");
@@ -46,15 +47,17 @@ public class MilestoneRepository {
     }
 
     public int insert(Milestone milestone) {
-        String sql = "insert into milestone(goal_id,title,content,date) values(?,?,?,?)";
+    // TODO:add column completed_at(completed flag)
+        String sql = "insert into milestone(goal_id,title,content,due_date) values(?,?,?,?)";
         return jdbcTemplate.update(sql, milestone.getGoalId(), milestone.getTitle(),
-                milestone.getContent(), milestone.getDate());
+                milestone.getContent(), milestone.getDueDate());
     }
 
     public int update(Milestone milestone) {
-        String sql = "update milestone set title=?,content=?,date=? where id=?";
+    // TODO:add column completed_at(completed flag)
+        String sql = "update milestone set title=?,content=?,due_date=? where id=?";
         return jdbcTemplate.update(sql, milestone.getTitle(), milestone.getContent(),
-                milestone.getDate(), milestone.getId());
+                milestone.getDueDate(), milestone.getId());
     }
 
     public int delete(int id) {

--- a/backend/src/main/java/com/calendar/milestone/model/service/MilestoneService.java
+++ b/backend/src/main/java/com/calendar/milestone/model/service/MilestoneService.java
@@ -17,6 +17,7 @@ public class MilestoneService {
     }
 
     public Milestone convertToMilestoneUpdate(MilestoneRequest milestoneRequest) {
+            // TODO:add column completed_at(completed flag)
         Milestone milestone = milestoneRepository.select(milestoneRequest.getId());
         milestone.setGoalId(milestoneRequest.getGoalId());
         if (milestoneRequest.getTitle() != null) {
@@ -25,19 +26,20 @@ public class MilestoneService {
         if (milestoneRequest.getContent() != null) {
             milestone.setContent(milestoneRequest.getContent());
         }
-        if (milestoneRequest.getDate() != null) {
-            milestone.setDate(milestoneRequest.getDate());
+        if (milestoneRequest.getDueDate() != null) {
+            milestone.setDueDate(milestoneRequest.getDueDate());
         }
         return milestone;
     }
 
     public MilestoneResponse convertToMilestoneResponse(Milestone milestone) {
+            // TODO:add column completed_at(completed flag)
         MilestoneResponse milestoneResponse = new MilestoneResponse();
         milestoneResponse.setId(milestone.getId());
         milestoneResponse.setGoalId(milestone.getGoalId());
         milestoneResponse.setTitle(milestone.getTitle());
         milestoneResponse.setContent(milestone.getContent());
-        milestoneResponse.setDate(milestone.getDate());
+        milestoneResponse.setDueDate(milestone.getDueDate());
         milestoneResponse.setCreatedAt(milestone.getCreatedAt());
         if (milestone.getUpdatedAt() != null) {
             milestoneResponse.setUpdatedAt(milestone.getUpdatedAt());
@@ -49,11 +51,12 @@ public class MilestoneService {
     }
 
     public int insert(MilestoneRequest milestoneRequest) {
+            // TODO:add column completed_at(completed flag)
         Milestone milestone = new Milestone();
         milestone.setGoalId(milestoneRequest.getGoalId());
         milestone.setTitle(milestoneRequest.getTitle());
         milestone.setContent(milestoneRequest.getContent());
-        milestone.setDate(milestoneRequest.getDate());
+        milestone.setDueDate(milestoneRequest.getDueDate());
         return milestoneRepository.insert(milestone);
     }
 


### PR DESCRIPTION
Renamed the milestone date field to dueDate to clarify that it represents the deadline. Updated milestone API JSON field names from snake_case to camelCase for consistency with the API naming convention.