### PR TITLE
refactor: simplify login response DTO

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/LoginResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/user/LoginResponse.java
@@ -1,36 +1,14 @@
 package com.calendar.milestone.controller.dto.response.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.calendar.milestone.controller.dto.response.common.ApiResponse;
 
 
-public class LoginResponse implements ApiResponse {
-    @JsonProperty("userId")
-    private int userId;
-
+public class LoginResponse  {
     @JsonProperty("token")
     private String token;
 
-    @JsonProperty("statusCode")
-    private Integer statusCode;
-
-    @JsonProperty("statusMessage")
-    private String statusMessage;
-
-    public LoginResponse(final int userId, final String token, final Integer statusCode,
-            final String statusMessage) {
-        this.userId = userId;
+    public LoginResponse(final String token) {
         this.token = token;
-        this.statusCode = statusCode;
-        this.statusMessage = statusMessage;
-    }
-
-    public int getUserId() {
-        return userId;
-    }
-
-    public void setUserId(int userId) {
-        this.userId = userId;
     }
 
     public String getToken() {
@@ -39,21 +17,5 @@ public class LoginResponse implements ApiResponse {
 
     public void setToken(String token) {
         this.token = token;
-    }
-
-    public Integer getStatusCode() {
-        return statusCode;
-    }
-
-    public void setStatusCode(Integer statusCode) {
-        this.statusCode = statusCode;
-    }
-
-    public String getStatusMessage() {
-        return statusMessage;
-    }
-
-    public void setStatusMessage(String statusMessage) {
-        this.statusMessage = statusMessage;
     }
 }


### PR DESCRIPTION
## Overview 
Simplified `LoginResponse` to align with the updated API response format. 
## Changes 
- Removed `userId` from `LoginResponse` 
- Removed `statusCode` from `LoginResponse`
- Removed `statusMessage` from `LoginResponse` 
## Reason 
`userId` does not need to be returned directly in the login response because it can be extracted from the JWT token. Common response fields such as `statusCode` and `statusMessage` are handled by the updated API response format.