### PR TITLE
refactor: separate email and password updates from profile request

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/request/user/UserPutRequest.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/request/user/UserPutRequest.java
@@ -2,15 +2,9 @@ package com.calendar.milestone.controller.dto.request.user;
 
 import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class UserPutRequest {
-
-    // NOTE: id must be Integer, not int
-    // because Jackson needs to handle null value during deserialization
-    @JsonProperty("id")
     private Integer id;
 
     @JsonProperty("name")
@@ -23,18 +17,6 @@ public class UserPutRequest {
 
     @JsonProperty("birthday")
     private LocalDate birthday;
-
-    @JsonProperty("email")
-    @Email
-    @Size(max = 30)
-    private String email;
-
-    @JsonProperty("password")
-    @Size(min = 8, max = 20, message = "Password must be between 8 and 20 characters.")
-    @Pattern(
-            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
-            message = "Password must contain uppercase, lowercase, digit, and special character.")
-    private String password;
 
     public Integer getId() {
         return id;
@@ -52,14 +34,6 @@ public class UserPutRequest {
         return birthday;
     }
 
-    public String getEmail() {
-        return email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
     public void setId(Integer id) {
         this.id = id;
     }
@@ -74,13 +48,5 @@ public class UserPutRequest {
 
     public void setBirthday(LocalDate birthday) {
         this.birthday = birthday;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 }


### PR DESCRIPTION
# Overview

Refactored `UserPutRequest` to separate email and password update responsibilities from user profile update.

# Changes

- Removed `email` field from `UserPutRequest`
- Removed `password` field from `UserPutRequest`
- Removed email and password validation annotations
- Removed `getEmail()` / `setEmail()`
- Removed `getPassword()` / `setPassword()`
- Removed unnecessary `@JsonProperty("id")` from the `id` field
- Removed unused imports related to email and password validation

# Reason

Email and password updates are now handled by dedicated request DTOs.

`UserPutRequest` should only be responsible for user profile update fields such as:

- `name`
- `photo`
- `birthday`

Also, the user id is extracted from the JWT token in the controller, so the `id` field should not be mapped from the request body.

# Note

This change clarifies the responsibility of `UserPutRequest` and prevents profile update logic from being mixed with email or password update logic.
