### PR TITLE
refactor: make ApiResponse a generic response wrapper

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiResponse.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/dto/response/common/ApiResponse.java
@@ -1,11 +1,16 @@
 package com.calendar.milestone.controller.dto.response.common;
 
-public interface ApiResponse {
-    Integer getStatusCode();
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-    void setStatusCode(Integer statusCode);
 
-    String getStatusMessage();
+public class ApiResponse<T> {
+    @JsonProperty
+    private T data;
+    @JsonProperty
+    private ApiStatus apiStatus; 
 
-    void setStatusMessage(String statusMessage);
+    public ApiResponse(final T data,final ApiStatus apiStatus){
+        this.data = data;
+        this.apiStatus = apiStatus;
+    }
 }


### PR DESCRIPTION
# Overview

Refactored `ApiResponse` to serve as a generic wrapper for API responses.

# Changes

- Added the generic type parameter `T`
- Added the `data` field to store response data
- Added the `apiStatus` field to store API status information
- Added a constructor to initialize each field
- Added `@JsonProperty` annotations for JSON serialization

# Purpose

This change allows each API-specific response DTO to be stored in `data`
and returned together with common API status information in a unified response format.