### PR TITLE
refactor: wrap user response in ApiResponse

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/UserController.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/UserController.java
@@ -52,10 +52,20 @@ public class UserController {
      * @return
      */
     @GetMapping
-    public UserResponse selectUser(@AuthenticationPrincipal Jwt jwt) {
-        return userService.select(jwtUserIdExtractor.extract(jwt));
+    public ApiResponse<UserResponse> select(@AuthenticationPrincipal Jwt jwt) {
+        final UserResponse userResponse = userService.select(jwtUserIdExtractor.extract(jwt));
+        final ApiResponse<UserResponse> apiResponse = new ApiResponse<UserResponse>(userResponse, ApiStatus.OK);
+        return apiResponse;
+
     }
 
+    /**
+     * ユーザ情報のうち、認証に使用しないプロフィール情報を更新する。
+     * 更新対象は name、photo、birthday とする。
+     * @param jwt
+     * @param user
+     * @return
+     */
     @PutMapping
     public int updateUser(@AuthenticationPrincipal Jwt jwt,
             @RequestBody @Valid UserPutRequest user) {


### PR DESCRIPTION
## Overview

Updated the user retrieval API to wrap the response data in `ApiResponse`.

This change unifies the response format with the other API endpoints.

## Changes

- Changed the return type from `UserResponse` to `ApiResponse<UserResponse>`
- Wrapped `UserResponse` in `ApiResponse`
- Added `ApiStatus.OK` to the response
- Renamed the controller method from `selectUser` to `select`