### PR TITLE
refactor: standardize email and password update responses

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/UserController.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/UserController.java
@@ -77,18 +77,22 @@ public class UserController {
 
 
     @PatchMapping("/email")
-    public UserApiStatusResponse userEmailUpdate(@AuthenticationPrincipal Jwt jwt,
+    public ApiResponse<Void> userEmailUpdate(@AuthenticationPrincipal Jwt jwt,
             @RequestBody @Valid UserEmailChangeRequest user) {
         MilestoneLogger.info("UserのEmail変更を開始");
         user.setId(jwtUserIdExtractor.extract(jwt));
-        return userService.emailUpdate(user);
+        final ApiStatus apiStatus = userService.emailUpdate(user);
+        final ApiResponse<Void> apiResponse = new ApiResponse<>(null, apiStatus);
+        return apiResponse;
     }
 
     @PatchMapping("/password")
-    public UserApiStatusResponse userPasswordUpdate(@AuthenticationPrincipal Jwt jwt,
+    public ApiResponse<Void> userPasswordUpdate(@AuthenticationPrincipal Jwt jwt,
             @RequestBody @Valid UserPasswordChangeRequest user) {
         user.setId(jwtUserIdExtractor.extract(jwt));
-        return userService.passwordUpdate(user);
+        final ApiStatus apiStatus = userService.passwordUpdate(user);
+        final ApiResponse<Void> apiResponse = new ApiResponse<>(null, apiStatus);
+        return apiResponse;
     }
 
     @DeleteMapping


### PR DESCRIPTION
# Overview

Standardized the response format for the user email and password update APIs.

# Changes

- Changed the return type of the email update API to `ApiResponse<Void>`
- Changed the return type of the password update API to `ApiResponse<Void>`
- Wrapped the `ApiStatus` returned from the service layer in `ApiResponse`
- Set `data` to `null` because these APIs only return the operation status

# Notes

- No changes were made to the email or password update logic
- This change only standardizes the API response format