### PR TITLE
feat: add JWT issuance for newly registered users

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/service/AuthService.java
+++ b/backend/src/main/java/com/calendar/milestone/model/service/AuthService.java
@@ -29,15 +29,22 @@ public class AuthService {
         final Email loginEmail = Email.of(loginRequest.getEmail());
         final RawPassword loginRawPassword = RawPassword.of(loginRequest.getPassword());
         if (!loginRawPassword.passwordMatch(userRepository.findPassword(loginEmail))) {
-            ApiStatus badApiStatus = ApiStatus.BAD_REQUEST;
-            return new UserApiStatusResponse(badApiStatus);
+    /**
+     * ユーザ新規登録時用のログイン認証
+     * @param user ユーザ新規登録の情報
+     * @return JWTトークン
+     * @throws IllegalArgumentException
+     */
+    public LoginResponse issueLoginToken(final UserPostRequest user) throws IllegalArgumentException{
+        final Email loginEmail = Email.of(user.getEmail());
+        final RawPassword loginRawPassword = RawPassword.of(user.getPassword());
+        if (!loginRawPassword.passwordMatch(userRepository.findPassword(loginEmail))) {
+            throw new IllegalArgumentException("Invalid email or password.");
         }
-        ApiStatus apiStatus = ApiStatus.OK;
         final UserId userId = userRepository.selectLoginUserId(loginEmail);
         final JwtPayload jwtPayload = JwtPayload.of(userId);
         final JwtToken jwtToken = JwtTokenGenerator.generateToken(key, jwtPayload);
-        ApiResponse loginResponse = new LoginResponse(userId.getValue(), jwtToken.getToken(),
-                apiStatus.getStatus(), apiStatus.getMessage());
+        LoginResponse loginResponse = new LoginResponse(jwtToken.getToken());
         return loginResponse;
     }
 }


### PR DESCRIPTION
# Overview

Added JWT token issuance logic for newly registered users.

This allows a user to receive a login token immediately after registration by using the email address and password contained in `UserPostRequest`.

# Changes

- Added an overloaded `issueLoginToken` method that accepts `UserPostRequest`
- Converted the email address and password into their respective value objects
- Validated the registered user's password against the stored password
- Retrieved the registered user's ID using the email address
- Created a JWT payload containing the user ID
- Generated a signed JWT and returned it as `LoginResponse`

# Purpose

Enable newly registered users to remain authenticated without requiring a separate login request immediately after registration.