### PR TITLE
refactor: update login response and error handling

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/model/service/AuthService.java
+++ b/backend/src/main/java/com/calendar/milestone/model/service/AuthService.java
@@ -2,10 +2,8 @@ package com.calendar.milestone.model.service;
 
 import org.springframework.stereotype.Service;
 import com.calendar.milestone.controller.dto.request.user.LoginRequest;
-import com.calendar.milestone.controller.dto.response.common.ApiResponse;
-import com.calendar.milestone.controller.dto.response.common.ApiStatus;
+import com.calendar.milestone.controller.dto.request.user.UserPostRequest;
 import com.calendar.milestone.controller.dto.response.user.LoginResponse;
-import com.calendar.milestone.controller.dto.response.user.UserApiStatusResponse;
 import com.calendar.milestone.model.config.JwtSigningKeyConfig;
 import com.calendar.milestone.model.repository.UserRepository;
 import com.calendar.milestone.model.value.Email;
@@ -25,10 +23,24 @@ public class AuthService {
         this.key = key;
     }
 
-    public ApiResponse issueLoginToken(LoginRequest loginRequest) {
+    /**
+     * ログイントークン認証。認可のちログイントークン
+     * @param loginRequest
+     * @return JWTトークン
+    */
+    public LoginResponse issueLoginToken(LoginRequest loginRequest) throws IllegalArgumentException {
         final Email loginEmail = Email.of(loginRequest.getEmail());
         final RawPassword loginRawPassword = RawPassword.of(loginRequest.getPassword());
         if (!loginRawPassword.passwordMatch(userRepository.findPassword(loginEmail))) {
+            throw new IllegalArgumentException("Invalid email or password.");
+        }
+        final UserId userId = userRepository.selectLoginUserId(loginEmail);
+        final JwtPayload jwtPayload = JwtPayload.of(userId);
+        final JwtToken jwtToken = JwtTokenGenerator.generateToken(key, jwtPayload);
+        LoginResponse loginResponse = new LoginResponse(jwtToken.getToken());
+        return loginResponse;
+    }
+
     /**
      * ユーザ新規登録時用のログイン認証
      * @param user ユーザ新規登録の情報


### PR DESCRIPTION
# Overview

Updated the existing login token issuance logic in `AuthService`.

The login response structure has been simplified, and password verification failures are now handled by throwing an exception instead of returning an API status response directly from the service layer.

# Changes

- Changed the return type of the login token issuance method from `ApiResponse` to `LoginResponse`
- Changed password verification failure handling to throw `IllegalArgumentException`
- Generated the JWT using `JwtTokenGenerator`
- Returned the generated token as `LoginResponse`
- Removed obsolete dependencies on `ApiStatus` and `UserApiStatusResponse`

# Purpose

- Align the login response with the updated API response structure
- Delegate authentication error response handling to the exception handling layer
- Simplify the responsibility of the login token issuance method