### PR TITLE
refactor: update login API response structure

### DIFF
--- a/backend/src/main/java/com/calendar/milestone/controller/AuthController.java
+++ b/backend/src/main/java/com/calendar/milestone/controller/AuthController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.calendar.milestone.controller.dto.request.user.LoginRequest;
 import com.calendar.milestone.controller.dto.response.common.ApiResponse;
+import com.calendar.milestone.controller.dto.response.common.ApiStatus;
+import com.calendar.milestone.controller.dto.response.user.LoginResponse;
 import com.calendar.milestone.model.service.AuthService;
 import jakarta.validation.Valid;
 
@@ -19,9 +21,16 @@ public class AuthController {
         this.authService = authService;
     }
 
+    /**
+     * ログイン
+     * @param loginRequest
+     * @return
+     */
     @PostMapping
-    public ApiResponse login(@RequestBody @Valid LoginRequest loginRequest) {
-        return authService.issueLoginToken(loginRequest);
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+        final LoginResponse loginResponse = authService.issueLoginToken(loginRequest);
+        final ApiResponse<LoginResponse> apiResponse = new ApiResponse<LoginResponse>(loginResponse,ApiStatus.OK);
+        return apiResponse;
     }
 
 


### PR DESCRIPTION
# Overview

Updated the existing login endpoint in `AuthController` to support the changed return type of the JWT token issuance method and the unified API response structure.

The `LoginResponse` returned by `AuthService` is now wrapped in `ApiResponse` before being returned to the client.

# Changes

- Changed the return type of the login endpoint to `ApiResponse<LoginResponse>`
- Received `LoginResponse` from the JWT token issuance method in `AuthService`
- Wrapped `LoginResponse` in the common `ApiResponse` structure
- Added `ApiStatus.OK` to the successful login response
- Added the required imports for `ApiStatus` and `LoginResponse`
- Added JavaDoc for the login endpoint

# Purpose

- Adapt `AuthController` to the changed return type of the JWT token issuance method
- Unify the login endpoint response with the common API response format
- Separate JWT generation from API response construction