### PR TITLE
build: add Lombok dependency

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,12 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
# Overview

Add Lombok as a project dependency to reduce boilerplate code when implementing DTOs.

# Changes

* Add the Lombok dependency to `pom.xml`
* Prepare the project to use Lombok annotations in future DTO implementations

# Verification

* Confirm that `mvn clean package` completes successfully
